### PR TITLE
Add SUDS fields who value can be determined by permit type

### DIFF
--- a/special-use/special-use-suds-mapping.json
+++ b/special-use/special-use-suds-mapping.json
@@ -72,9 +72,13 @@
           "operatingPlan": {
       			"description": "A completed Word or RTF operating plan template.",
             "type": "file"
-          }
-      	},
-        "required": ["orgType","insuranceCertificate","goodStandingEvidence","operatingPlan"]
+          },
+          "pre-determined-suds-fields" : {
+            "!COMMENT" : "If the permit type is temporary outfitter/guide, these fields can be set in SUDS without any additional input from the API user.",
+            "crExempt" : { "type" : "string", "suds-application" : "Application", "suds-field" : "value", "yes"},
+            "code" : { "type" : "integer", "suds-application" : "Application", "suds-field" : "value", "153"}
+          },
+         "required": ["orgType","insuranceCertificate","goodStandingEvidence","operatingPlan"]
       },
     },
     "type": "object",

--- a/special-use/special-use-suds-mapping.json
+++ b/special-use/special-use-suds-mapping.json
@@ -53,7 +53,13 @@
           "startDateTime": { "type": "dateTime", "suds-table": "application", "suds-field" : "remarks"},
           "endDateTime": { "type": "dateTime", "suds-table": "application", "suds-field" : "remarks" },
           "numberParticipants" : { "type": "integer",  "suds-field" : "remarks" }
-      		},
+          },
+        "pre-determined-suds-fields":
+        {
+          "!COMMENT" : "If the permit type is non-commercial, these fields can be set in SUDS without any additional input from the API user.",
+          "crExempt" : { "type" : "string", "suds-application" : "Application", "suds-field" : "value", "yes"},
+          "Code" : { "type" : "integer", "suds-application" : "Application", "suds-field" : "value", "191"}
+        }
       },
       "temp-outfitter-fields": {
         "type": "object",
@@ -66,7 +72,7 @@
           "operatingPlan": {
       			"description": "A completed Word or RTF operating plan template.",
             "type": "file"
-          },
+          }
       	},
         "required": ["orgType","insuranceCertificate","goodStandingEvidence","operatingPlan"]
       },

--- a/special-use/special-use-suds-mapping.json
+++ b/special-use/special-use-suds-mapping.json
@@ -58,7 +58,7 @@
         {
           "!COMMENT" : "If the permit type is non-commercial, these fields can be set in SUDS without any additional input from the API user.",
           "crExempt" : { "type" : "string", "suds-application" : "Application", "suds-field" : "value", "no"},
-          "Code" : { "type" : "integer", "suds-application" : "Application", "suds-field" : "value", "191"}
+          "code" : { "type" : "integer", "suds-application" : "Application", "suds-field" : "value", "191"}
         }
       },
       "temp-outfitter-fields": {

--- a/special-use/special-use-suds-mapping.json
+++ b/special-use/special-use-suds-mapping.json
@@ -57,7 +57,7 @@
         "pre-determined-suds-fields":
         {
           "!COMMENT" : "If the permit type is non-commercial, these fields can be set in SUDS without any additional input from the API user.",
-          "crExempt" : { "type" : "string", "suds-application" : "Application", "suds-field" : "value", "yes"},
+          "crExempt" : { "type" : "string", "suds-application" : "Application", "suds-field" : "value", "no"},
           "Code" : { "type" : "integer", "suds-application" : "Application", "suds-field" : "value", "191"}
         }
       },


### PR DESCRIPTION
These changes note several SUDS fields whose value can be determined based on the permit type (without any additional input from the API endpoint or user). 

@lauraGgit, does the way I did this make sense? Open to other approaches, too.