### PR TITLE
Updating POST and GET schema

### DIFF
--- a/special-use/special-use-GET-suds-mapping.json
+++ b/special-use/special-use-GET-suds-mapping.json
@@ -21,7 +21,7 @@
       			"description": "The name of the group, company, organization or event applying, if CONTACT_TYPE is organization",
       			"type": "integer",
       		},
-          "website": { "type": "string", "note" : "Store in middle layer." },
+          "website": { "type": "string", "stored-in-middle-layer": true },
           "orgType": { "type": { "enum": [ "Individual"  , "Corporation"  , "Limited Liability Company"  , "Partnership or Association"  , "State Government or Agency"  , "Local Government or Agency"  , "Nonprofit" ] }, "basic-api-field" : "ORG_TYPE, ORG_CODE" },
         "required": ["firstName","lastName","dayPhone","emailAddress","mailingAddress","mailingCity","mailingZIP","mailingState"]
       },

--- a/special-use/special-use-GET-suds-mapping.json
+++ b/special-use/special-use-GET-suds-mapping.json
@@ -58,24 +58,24 @@
           "experienceList": { "type": "string"},
           "guideDocumentation": {
             "type": "file",
-            "note": "Stored in the middle layer.",
+            "stored-in-middle-layer": true,
           },
           "acknowledgementOfRiskForm": {
             "type": "file",
-            "note": "Stored in the middle layer.",
+            "stored-in-middle-layer": true,
           },
       		"insuranceCertificate": {
             "type": "file",
-            "note": "Stored in the middle layer.",
+            "stored-in-middle-layer": true,
           },
           "goodStandingEvidence": {
       			"description": "Required for all non-individual contact types. Certificate of good standing, operating agreement, or other evidence the business is in good standing",
-            "note": "Stored in the middle layer.",
+            "stored-in-middle-layer": true,
             "type": "file"
           },
           "operatingPlan": {
       			"description": "A completed Word or RTF operating plan template.",
-            "note": "Stored in the middle layer.",
+            "stored-in-middle-layer": true,
             "type": "file"
           },
       },

--- a/special-use/special-use-GET-suds-mapping.json
+++ b/special-use/special-use-GET-suds-mapping.json
@@ -49,21 +49,35 @@
       "temp-outfitter-fields": {
         "type": "object",
         "properties": {
+          "individualIsCitizen" : { "type" : "boolean", "note" : "Required if contactType is individual."},
+          "smallBusiness" : { "type" : "boolean", "note" : "Required if contactType is not individual."},
+          "activityDescription": { "type": "string"},
+          "advertisingURL": { "type": "URL", "note" : "Either advertisingURL or advertisingDescription must be complete."},
+          "advertisingDescription": { "type": "string", "note" : "Either advertisingURL or advertisingDescription must be complete."},
+          "clientCharges": { "type": "string"},
+          "experienceList": { "type": "string"},
+          "guideDocumentation": {
+            "type": "file",
+            "note": "Stored in the middle layer.",
+          },
+          "acknowledgementOfRiskForm": {
+            "type": "file",
+            "note": "Stored in the middle layer.",
+          },
       		"insuranceCertificate": {
             "type": "file",
             "note": "Stored in the middle layer.",
           },
           "goodStandingEvidence": {
-      			"description": "Certificate of good standing, operating agreement, or other evidence the business is in good standing",
-            "note": "This file should be stored in the middle layer and retrieved (if available) with a GET request.",
+      			"description": "Required for all non-individual contact types. Certificate of good standing, operating agreement, or other evidence the business is in good standing",
+            "note": "Stored in the middle layer.",
             "type": "file"
           },
           "operatingPlan": {
       			"description": "A completed Word or RTF operating plan template.",
-            "note": "This file should be stored in the middle layer and retrieved (if available) with a GET request.",
+            "note": "Stored in the middle layer.",
             "type": "file"
           },
-         "required": ["insuranceCertificate","goodStandingEvidence","operatingPlan"]
       },
     },
     "type": "object",

--- a/special-use/special-use-POST-data-schema.json
+++ b/special-use/special-use-POST-data-schema.json
@@ -21,7 +21,7 @@
       			"type": "integer",
       		},
           "website": { "type": "string", "note" : "Store in middle layer." },
-          "orgType": { "type": { "enum": [ "Individual"  , "Corporation"  , "Limited Liability Company"  , "Partnership or Association"  , "State Government or Agency"  , "Local Government or Agency"  , "Nonprofit" ] }},
+          "orgType": { "type": { "enum": [ "Association","Corporation","Education","Federal Government","State Government","Local Govt","Married Common Property","Limited Liability Company (LLC)","Limited Liability Corporation (LLP)","Trust" ] }},
         "required": ["firstName","lastName","dayPhone","emailAddress","mailingAddress","mailingCity","mailingZIP","mailingState"]
       },
       "phoneNumber": {

--- a/special-use/special-use-POST-data-schema.json
+++ b/special-use/special-use-POST-data-schema.json
@@ -84,8 +84,6 @@
       "region": { "type" : "integer" },
       "forest": { "type" : "integer" },
       "district": { "type" : "integer" },
-      "authorizingOfficerName": { "type" : "string"},
-      "authorizingOfficerTitle": { "type" : "string"},
       "applicant-info" : {
         "oneOf" : [
           { "$ref": "#/definitions/applicant-info" },

--- a/special-use/special-use-POST-data-schema.json
+++ b/special-use/special-use-POST-data-schema.json
@@ -20,7 +20,7 @@
       			"description": "The name of the group, company, organization or event applying",
       			"type": "integer",
       		},
-          "website": { "type": "string", "note" : "Store in middle layer." },
+          "website": { "type": "string", "stored-in-middle-layer": true },
           "orgType": { "type": { "enum": [ "Association","Corporation","Education","Federal Government","State Government","Local Govt","Married Common Property","Limited Liability Company (LLC)","Limited Liability Corporation (LLP)","Trust" ] }},
         "required": ["firstName","lastName","dayPhone","emailAddress","mailingAddress","mailingCity","mailingZIP","mailingState"]
       },

--- a/special-use/special-use-POST-suds-mapping-post.json
+++ b/special-use/special-use-POST-suds-mapping-post.json
@@ -23,7 +23,7 @@
             "basic-api-endpoint": "/contact/organization",
             "required-by-basic-api": true
       		},
-          "website": { "type": "string", "note" : "Store in middle layer." },
+          "website": { "type": "string", "stored-in-middle-layer": true },
           "orgType": {
             "type": { "enum": [ "Association","Corporation","Education","Federal Government","State Government","Local Govt","Married Common Property","Limited Liability Company (LLC)","Limited Liability Corporation (LLP)","Trust" ] },
             "basic-api-field" : "orgType",
@@ -57,11 +57,11 @@
       "non-commercial-fields": {
         "type": "object",
         "properties": {
-      		"activityDescription": { "type": "string", "note" : "Store in middle layer."},
-      		"locationDescription": {	"type": "string", "note" : "Store in middle layer."},
-          "startDateTime": { "type": "dateTime", "note" : "Store in middle layer."},
-          "endDateTime": { "type": "dateTime", "note" : "Store in middle layer." },
-          "numberParticipants" : { "type": "integer", "note" : "Store in middle layer." },
+      		"activityDescription": { "type": "string", "stored-in-middle-layer": true},
+      		"locationDescription": {	"type": "string", "stored-in-middle-layer": true},
+          "startDateTime": { "type": "dateTime", "stored-in-middle-layer": true},
+          "endDateTime": { "type": "dateTime", "stored-in-middle-layer": true },
+          "numberParticipants" : { "type": "integer", "stored-in-middle-layer": true },
           "AUTOPOPULATED_BY_MIDDLEWARE_NOT_INTAKE_MODULE": {
             "basic-api-field": "purpose",
             "basic-api-endpoint": "/contact/application",
@@ -111,9 +111,9 @@
     },
     "type": "object",
     "properties": {
-      "region": { "type" : "integer", "note" : "Store in middle layer."},
-      "forest": { "type" : "integer", "note" : "Store in middle layer." },
-      "district": { "type" : "integer", "note" : "Store in middle layer."},
+      "region": { "type" : "integer", "stored-in-middle-layer": true},
+      "forest": { "type" : "integer", "stored-in-middle-layer": true },
+      "district": { "type" : "integer", "stored-in-middle-layer": true},
       "applicant-info" : {
         "oneOf" : [
           { "$ref": "#/definitions/applicant-info" },


### PR DESCRIPTION
Following our substantial changes to the mapping, I wanted to make a few corrective changes to the POST and GET schemas:

- Adding the additional outfitters/guides documentation fields in the GET schema
- Removing the authorizing officer fields from the POST schema
- Fixing the orgType options in the POST schema to match the mapping (and SUDS)